### PR TITLE
Fix: String' is not convertible to 'Range<I>

### DIFF
--- a/FlatUIColors.swift
+++ b/FlatUIColors.swift
@@ -33,7 +33,7 @@ public struct FlatUIColors
             colorString = colorString.fui_substringFromIndex(1)
         }
 
-        let stringLength = count(colorString)
+        let stringLength = strlen(colorString)
         if stringLength != 6 && stringLength != 8 {
             return nil
         }


### PR DESCRIPTION
Fix for:
FlatUIColors.swift:36:34: 'String' is not convertible to 'Range<I>'
